### PR TITLE
tweak color offset for pie chart

### DIFF
--- a/ETHDINFKBot/Drawing/PieChart.cs
+++ b/ETHDINFKBot/Drawing/PieChart.cs
@@ -148,7 +148,7 @@ namespace ETHDINFKBot.Drawing
                 (double L, double c, double h) = linear_srgb_to_oklab(SKColor.FromHsl(0, 70, 50));
                 //h += 255 * (i / (float)sizeLabels);
                 double oldHue = h;
-                h = 2 * Math.PI * (i / (float)sizeLabels);
+                h = (2*Math.PI * i / sizeLabels + Math.PI*3/2) % (2*Math.PI);
 
                 /*if(i % 2 == 0)
                     h += Math.PI;


### PR DESCRIPTION
I changed the line of code that determines the hue inside the pie chart drawing loop. The angle (in radians) now has an additional offset, supposed to make it start at blue. I also added `.. % (2*Math.PI)` so the value is guaranteed to be within `[0,2π)` as we keep rotating with increasing angles.